### PR TITLE
Onboarding: Back button should be disabled instead of loading

### DIFF
--- a/Extension/src/pages/options/OnboardingPage/components/Steps.jsx
+++ b/Extension/src/pages/options/OnboardingPage/components/Steps.jsx
@@ -100,7 +100,7 @@ function StepsNavigation({
                     <Button
                         variant="secondary-black"
                         onClick={onBack}
-                        loading={isLoading}
+                        disabled={isLoading}
                         size="large"
                         name={`btn-back_${state.value}`}
                     >


### PR DESCRIPTION
I think this makes a bit more sense. 