### PR TITLE
feat: inject headers for qwant.com to help detect extension ssr

### DIFF
--- a/Extension/src/background/webrequest.js
+++ b/Extension/src/background/webrequest.js
@@ -57,6 +57,28 @@ const webrequestInit = function () {
     const shouldUseInsertCSSAndExecuteScript = prefs.features.canUseInsertCSSAndExecuteScript;
 
     /**
+     * Detect if the requestUrl is on qwant.com host
+     * @param {RequestDetails} requestDetails - Request details
+     * @returns {boolean} True if request url is part of qwant.com
+     */
+    function isQwantHost(requestDetails) {
+        return /^(https:\/\/)?(www\.)?qwant\.com/i.test(requestDetails?.requestUrl);
+    }
+
+    /**
+     * Inject specific headers in qwant.com urls for better extension installed detection.
+     * @returns {*} headers to send.
+     */
+    function getQwantSpecificHeaders(requestHeaders) {
+        return {
+            requestHeaders: [
+                ...requestHeaders,
+                { name: 'X-Qwant-Ext-Installed', value: '1' },
+            ],
+        };
+    }
+
+    /**
      * Retrieve referrer url from request details.
      * Extract referrer by priority:
      * 1. referrerUrl in requestDetails
@@ -320,6 +342,10 @@ const webrequestInit = function () {
         requestContextStorage.update(requestId, { requestHeaders });
 
         let requestHeadersModified = false;
+
+        if (isQwantHost(requestDetails)) {
+            return getQwantSpecificHeaders(requestHeaders);
+        }
 
         if (requestType === RequestTypes.DOCUMENT) {
             // Save ref header


### PR DESCRIPTION
The point is to ease the detection of Qwant VIPrivacy already installed by injecting a new header `X-Qwant-Ext-Installed` in qwant.com requests. 

With this, we can enhance the experience of users which already have extension installed to : not showing some call to action to install the extension on qwant.com, avoid some blinks effects due to server side rendering etc...